### PR TITLE
Fix data source configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,13 @@
 			<artifactId>hsqldb</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/com/example/DemoApplication.java
+++ b/src/main/java/com/example/DemoApplication.java
@@ -1,6 +1,6 @@
 package com.example;
 
-import javax.sql.DataSource;
+import com.zaxxer.hikari.HikariDataSource;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -26,8 +26,9 @@ public class DemoApplication {
 	@Primary
 	@Bean
 	@ConfigurationProperties(prefix = "first")
-	public DataSource primaryDataSource() {
-		return primaryDataSourceProperties().initializeDataSourceBuilder().build();
+	public HikariDataSource primaryDataSource() {
+		return (HikariDataSource) primaryDataSourceProperties().initializeDataSourceBuilder()
+				.type(HikariDataSource.class).build();
 	}
 
 	@Bean
@@ -38,7 +39,8 @@ public class DemoApplication {
 
 	@Bean("second")
 	@ConfigurationProperties(prefix = "second")
-	public DataSource secondaryDataSource() {
-		return secondaryDataSourceProperties().initializeDataSourceBuilder().build();
+	public HikariDataSource secondaryDataSource() {
+		return (HikariDataSource) secondaryDataSourceProperties().initializeDataSourceBuilder()
+				.type(HikariDataSource.class).build();
 	}
 }

--- a/src/main/java/com/example/DemoApplication.java
+++ b/src/main/java/com/example/DemoApplication.java
@@ -16,16 +16,29 @@ public class DemoApplication {
 		SpringApplication.run(DemoApplication.class, args);
 	}
 
+	@Bean
+	@Primary
+	@ConfigurationProperties("first")
+	public DataSourceProperties primaryDataSourceProperties() {
+		return new DataSourceProperties();
+	}
+
 	@Primary
 	@Bean
-	@ConfigurationProperties(prefix = "spring.datasource")
-	public DataSource primaryDataSource(DataSourceProperties properties) {
-		return properties.initializeDataSourceBuilder().build();
+	@ConfigurationProperties(prefix = "first")
+	public DataSource primaryDataSource() {
+		return primaryDataSourceProperties().initializeDataSourceBuilder().build();
+	}
+
+	@Bean
+	@ConfigurationProperties("second")
+	public DataSourceProperties secondaryDataSourceProperties() {
+		return new DataSourceProperties();
 	}
 
 	@Bean("second")
 	@ConfigurationProperties(prefix = "second")
-	public DataSource secondaryDataSource(DataSourceProperties properties) {
-		return properties.initializeDataSourceBuilder().build();
+	public DataSource secondaryDataSource() {
+		return secondaryDataSourceProperties().initializeDataSourceBuilder().build();
 	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,9 @@
-spring.datasource.url=jdbc:h2:file:./target/h2-primary
-spring.datasource.driver-class-name=org.h2.Driver
-#spring.datasource.type=com.zaxxer.hikari.HikariDataSource
-#spring.datasource.hikari.maximum-pool-size=20
+first.url=jdbc:h2:file:./target/h2-primary
+#first.driver-class-name=org.h2.Driver
+first.type=com.zaxxer.hikari.HikariDataSource
+first.maximum-pool-size=20
 
 second.url=jdbc:hsqldb:file:./target/hsql-secondary
-second.driver-class-name=org.hsqldb.jdbcDriver
-#second.hikari.maximum-pool-size=20
-#second.type=com.zaxxer.hikari.HikariDataSource
+#second.driver-class-name=org.hsqldb.jdbcDriver
+second.type=com.zaxxer.hikari.HikariDataSource
+second.maximum-pool-size=20

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,7 @@
 first.url=jdbc:h2:file:./target/h2-primary
 #first.driver-class-name=org.h2.Driver
-first.type=com.zaxxer.hikari.HikariDataSource
 first.maximum-pool-size=20
 
 second.url=jdbc:hsqldb:file:./target/hsql-secondary
 #second.driver-class-name=org.hsqldb.jdbcDriver
-second.type=com.zaxxer.hikari.HikariDataSource
 second.maximum-pool-size=20


### PR DESCRIPTION
`DataSourceProperties` is itself bound to the environment. If you are
using the same object with two completely different datasources, you
will not get the expected result.

Let's take a step back to better understand what happens by default in
Spring Boot. `DataSourceProperties` is used to share basic settings
about your datasource such as the url, the username, the password and
the datasource implementation to use. Additional settings can be set
using a specific namespace (i.e. `spring.datasource.hikari`) for Hikari
as not all implementations share the same settings.

There are several problems in your current setup.

First of all you are using the hikari namespace specific setup while you
are exposing your hikari datasource as `spring.datasource`. There's no
magic here: if you ask Spring Boot to expose your datasource as
`spring.datasource`, it won't read keys that start with
`spring.datasource.hikari`.

Second, which is the most problematic, you are using the same
`DataSourceProperties` for both datasources. It is exposed on
`spring.datasource` by default so it happens to work for the first
datasource only because you named it `spring.datasource` yourself. The
reason why it breaks is because you're trying to set the HSQL driver on
an H2 url. Hikari doesn't have a `setUrl` method so the `second.url`
attribute is ignored. You're therefore initializing the second datasource
with the basic settings of the first.

Before this commit, all basic settings from `spring.datasource` were set
on both datasource (since you're sharing the same `DataSourceProperties`)
and the `maximum-pool-size` parameter was ignored since you have a custom
namespace for your datasources.

I've reworked your configuration so that it does what is expected, I've
also renamed `spring.datasource` to `first` to make more obvious what is
happening. The first `DataSourceProperties` being primary, it will be the
one used by Spring Boot if it needs one (i.e. `DatabaseInitializer`). As
Spring Boot auto-detects the driver to use, I've commented that out since
it isn't necessary.